### PR TITLE
Improve APY calculation

### DIFF
--- a/src/contexts/stats.js
+++ b/src/contexts/stats.js
@@ -152,10 +152,10 @@ export function StatsProvider({ children }) {
 
   const apy = React.useMemo(() => {
 
-    let BNB_APY = (bnbUSDPrice * 250) / totalUSDDeposits * 1730;
-
     if (!(!isZero(monthlyUnlockRate) && !isZero(totalUSDDeposits)))
       return Big('0');
+
+    let BNB_APY = bnbUSDPrice.mul(250).div(totalUSDDeposits).mul(1730);
 
     let apy = monthlyUnlockRate
       .div(totalUSDDeposits)

--- a/src/contexts/stats.js
+++ b/src/contexts/stats.js
@@ -133,12 +133,12 @@ export function StatsProvider({ children }) {
     if (!(!isZero(totalLockedShares) && !isZero(totalLocked) && schedules))
       return Big('0');
 
-    const s = totalLockedShares.div(1e18);
-    const a = totalLocked;
-    const m = parseInt(Date.now() / 1e3);
-    const i = Big(2592e3);
+    const totalLockedSharesNormalized = totalLockedShares.div(1e18);
 
-    const vaa = schedules.reduce((t, schedule) => {
+    const m = parseInt(Date.now() / 1e3);
+    const i = Big(604800);
+
+    const scheduleSharesEmitted = schedules.reduce((t, schedule) => {
       return t.add(
         op(ip(schedule.endAtSec.sub(m), Big('0')), i)
           .div(schedule.durationSec)
@@ -146,24 +146,27 @@ export function StatsProvider({ children }) {
       );
     }, Big('0'));
 
-    return isZero(a) ? Big('0') : vaa.div(a).mul(s);
+    return isZero(totalLocked) ? Big('0') : scheduleSharesEmitted.div(totalLockedShares).mul(totalLocked).div(1e9);
+
   }, [totalLockedShares, totalLocked, schedules]);
 
   const apy = React.useMemo(() => {
+
+    let BNB_APY = (bnbUSDPrice * 250) / totalUSDDeposits * 1730;
+
     if (!(!isZero(monthlyUnlockRate) && !isZero(totalUSDDeposits)))
       return Big('0');
 
     let apy = monthlyUnlockRate
-      .add(CAKE_APY.div(12))
       .div(totalUSDDeposits)
-      .mul(12);
+      .mul(52)
+      .mul(100)
+      .add(CAKE_APY)
+      .add(BNB_APY);
 
     if (apy.gte(1e6)) {
       apy = Big(1e6);
     }
-
-    // todo:
-    apy = apy.div(5);
 
     return apy;
   }, [monthlyUnlockRate, totalUSDDeposits]);


### PR DESCRIPTION
Calculate APY in a more realistic way. BNB rewards APY for the first 3-weeks schedule is hardcoded for now.